### PR TITLE
feat: Add deployment metrics and improve context/namespace switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 A command-line tool for managing Kubernetes resources with enhanced features and user-friendly output.
 
-![k8stool terminal demo](./images/k8stool.png)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,56 @@ A command-line tool for managing Kubernetes resources with enhanced features and
   k8stool describe deploy nginx       # Short alias
   ```
 
+### Resource Metrics
+- ✅ View resource utilization metrics
+  ```bash
+  k8stool metrics pods                # Show metrics for all pods
+  k8stool metrics nodes               # Show metrics for all nodes
+  k8stool metrics <pod-name>          # Show metrics for specific pod
+  k8stool get pods --metrics          # Show pod metrics in pod list
+  k8stool get deploy --metrics        # Show aggregated deployment metrics
+  ```
+  - Real-time CPU and Memory usage
+  - Supports both pods and deployments
+  - Requires metrics-server installed
+
+### Context Management
+- ✅ Switch between Kubernetes contexts
+  ```bash
+  k8stool ctx current                # Show curret context
+  k8stool context current            # Show curret context
+  k8stool ctx <context-name>         # Switch to specific context
+  k8stool context <context-name>     # Switch to specific context (long form)
+  k8stool ctx switch                 # Interactive mode
+  k8stool context switch             # Interactive mode
+  ```
+  - Interactive mode:
+    - Lists all available contexts
+    - Shows current context highlighted
+    - Arrow key navigation
+    - Enter to select context
+  - Shows current context
+  - Easy context switching
+  - Displays associated clusters
+
+### Namespace Management
+- ✅ Switch between namespaces
+  ```bash
+  k8stool ns                         # show current namespace
+  k8stool namespace                  # show current namespace
+  k8stool ns <namespace-name>        # Switch to specific namespace
+  k8stool namespace <namespace-name> # Switch to specific namespace (long form)
+  k8stool ns -i                      # Switch to specific namespace
+  k8stool namespace -i               # Switch to specific namespace (long form)
+  ```
+  - Interactive mode:
+    - Lists all available namespaces
+    - Shows current namespace highlighted
+    - Arrow key navigation
+    - Enter to select namespace
+  - Shows current namespace
+  - Easy namespace switching
+
 ## Requirements
 
 - Kubernetes cluster with metrics-server installed (for metrics feature)


### PR DESCRIPTION
## Changes
- Added `--metrics` flag to `get deployments` command to show aggregated pod metrics
- Added metrics support for individual pod queries (`metrics <pod-name>`)
- Enhanced context switching with interactive mode
- Enhanced namespace switching with interactive mode
- Updated documentation with new features

## Features
### Deployment Metrics
- Shows aggregated CPU and Memory usage for all pods in a deployment
- Integrates with existing metrics display system
- Requires metrics-server to be installed in the cluster

### Interactive Mode Improvements
- Context switching now supports interactive selection
  - Lists all available contexts
  - Highlights current context
  - Arrow key navigation
  - Enter to select

- Namespace switching now supports interactive selection
  - Lists all available namespaces
  - Highlights current namespace
  - Arrow key navigation
  - Enter to select

